### PR TITLE
Nested router

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galaxite.js",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "src/index.js",
   "types": "@types/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -3,23 +3,15 @@ const { getBody, parseCookies, pathExists, provideFile } = require("./lib/parser
 const { ResponseHelpers, ServerOptions } = require("./lib/extenders");
 const Router = require("./lib/router");
 class GalaxiteServer {
+  static Router = Router;
   constructor(options = {}) {
     this.options = new ServerOptions(options);
     this.router = new Router();
     this.middlewares = [];
   }
 
-  route(endpoint) {
-    const route = {};
-
-    ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'].forEach((method) => {
-      route[method.toLowerCase()] = (handler) => {
-        this.router.addRoute(method, endpoint, handler);
-        return route;
-      };
-    });
-
-    return route;
+  route(...args) {
+    return this.router.route(...args)
   }
 
   use(middleware) {

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -13,6 +13,38 @@ class Router {
         this.root = new RouterNode();
     }
 
+    route(endpoint, nestedRouter = null) {
+        if (!!nestedRouter) {
+            const parts = endpoint.split('/');
+            let node = this.root;
+            for (let i = endpoint.startsWith('/') ? 1 : 0; i < parts.length; i++) {
+                const part = parts[i];
+                if (part.length === 0) continue;
+                let child = node.children.find((c) => c.key === part);
+                if (!child) {
+                    child = new RouterNode(part);
+                    if (part.startsWith(':')) child.isParam = true;
+                    if (part === '*') child.isWildcard = true;
+                    node.children.push(child);
+                }
+                node = child;
+            }
+            node.handler = nestedRouter.root.handler
+            node.children = [...node.children, ...nestedRouter.root.children]
+            return true;
+        }
+
+        const route = {};
+        ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'].forEach((method) => {
+          route[method.toLowerCase()] = (handler) => {
+            this.addRoute(method, endpoint, handler);
+            return route;
+          };
+        });
+    
+        return route;
+    }
+
     addRoute(method, endpoint, handler) {
         const parts = endpoint.split('/');
         let node = this.root;
@@ -24,7 +56,7 @@ class Router {
                 child = new RouterNode(part);
                 if (part.startsWith(':')) child.isParam = true;
                 if (part === '*') child.isWildcard = true;
-                node.children.push(child);
+                node.children[child.isWildcard || child.isParam ? 'push' : 'unshift'](child);
             }
             node = child;
         }
@@ -42,32 +74,33 @@ class Router {
         const segments = path.split('/').filter((segment) => segment !== '');
         let currentNode = this.root;
         const params = {};
-
+        let found = false;
         for (const segment of segments) {
-            let found = false;
             let wildcardEntryFound = false;
+            found = false;
             for (const child of currentNode.children) {
                 if (child.isParam && !child.isWildcard) {
                     params[child.key.slice(1)] = decodeURIComponent(segment);
                     currentNode = child;
                     found = true;
                     break;
-                } else if (child.isWildcard) {
+                }
+                if (child.isWildcard) {
                     params['slug'] = decodeURIComponent(segments.slice(segments.indexOf(segment)).join('/'));
                     currentNode = child;
                     found = wildcardEntryFound = true;
                     break;
-                } else if (child.key === segment) {
+                }
+                if (child.key === segment) {
                     currentNode = child;
                     found = true;
                     break;
                 }
             }
-            if (wildcardEntryFound) break
+            if (!found || wildcardEntryFound) break
         }
-
         return {
-            handler: (currentNode.handler) ? currentNode.handler[method] : null,
+            handler: (found && currentNode.handler) ? currentNode.handler[method] : null,
             router: { query: { ...qs.parse(query) }, path: path || '/', params, method },
         };
     }


### PR DESCRIPTION
## Version 1.3.0
### Description
This version extends router functionality by allowing nested routes declaration.

### Example
`router_users.js` - contains nested routes for `/users`
```javascript
const { Router } = require("./src");

const nestedRouter = new Router();

nestedRouter.route("/").get((req, res) => {
    return res.status(200).json(req.router);
});
nestedRouter.route("/:id").get((req, res) => {
    return res.status(200).json(req.router);
});
nestedRouter.route("/scope/:id").get((req, res) => {
    return res.status(200).json(req.router);
});

module.exports = nestedRouter;
```


Entry point - `index.js`
```javascript
const Galaxite = require("galaxite.js");
const server = new Galaxite();

const usersRouter = require('./router_users');

server.route("/users", usersRouter); // now we have "/users", "/users/:id", "/users/scope/:id"

server.listen(3000, (port) => console.log(`Listening on :${port}`));
``` 